### PR TITLE
Better exception handling; Cascade item deletion

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -6,8 +6,18 @@ from telegram.ext import CommandHandler
 
 cmd_list = ['adadd', 'addelete', 'adinit', 'adinventario', 'adnewchangelog', 'adsetadmin', 'adupdate', 'broadcast', 'conta', 'containv', 'help', 'helpcomandi', 'helpcontribuisci', 'inventario', 'start', 'ultimi', 'confronta', 'confrontainv', 'fine', 'annulla']
 
+
+def reply_exception_wrapper(handler):
+	def new_handler(bot, update, *args, **kwargs):
+		try:
+			return handler(bot, update, *args, **kwargs)
+		except Exception as ex:
+			update.message.reply_text('ERRORE: {}'.format(str(ex)))
+	return new_handler
+
+
 handlers = []
 for c in cmd_list:
 	m = importlib.import_module('.'+c, __name__)
 	args = m.pass_args
-	handlers.append(CommandHandler(c, m.run, pass_args=args))
+	handlers.append(CommandHandler(c, reply_exception_wrapper(m.run), pass_args=args))

--- a/commands/addelete.py
+++ b/commands/addelete.py
@@ -8,11 +8,10 @@ pass_args = True
 
 def run(bot, update, args):
 	if utils.is_from_admin(update):
-		if not all(map(str.isdigit, args)):
+		if len(args) == 0 or not all(map(str.isdigit, args)):
 			update.message.reply_text('Specifica gli id degli item da eliminare')
 		else:
 			dbitems = database.items.DbItems()
 			for itemid in args:
-				itemid = int(itemid)
-				dbitems.delete(itemid)
+				dbitems.delete(int(itemid))
 			update.message.reply_text('Fatto.')

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -74,7 +74,7 @@ class Database:
 				   SELECT {admin_id}, '', true
 				   WHERE NOT EXISTS (SELECT * FROM users WHERE id = {admin_id});
 				 CREATE TABLE IF NOT EXISTS user_items (
-				   itemid   INTEGER REFERENCES items(id),
+				   itemid   INTEGER REFERENCES items(id) ON DELETE CASCADE,
 				   userid   BIGINT  REFERENCES users(id),
 				   quantity INTEGER NOT NULL DEFAULT 0,
 				   state VARCHAR,

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -40,6 +40,7 @@ class Database:
 			self.connection.commit()
 		except Exception as ex:
 			logger.error(str(ex))
+			raise ex
 
 	def _read(self, sql, args=tuple()):
 		# Executes a query which doesn't modify the database but returns data
@@ -51,6 +52,7 @@ class Database:
 				result = cursor.fetchall()
 		except Exception as ex:
 			logger.error(str(ex))
+			raise ex
 		return result
 
 	def build(self):


### PR DESCRIPTION
A user reported that a duplicated item with outdated name.
The `addelete` command was doing nothing, but also not showing any error.

The issue was that the item was referenced in the `user_items` table, so the foreign key constraint was preventing the deletion from the `items` table.

It was fixed by adding `ON DELETE CASCADE` to `FOREIGN KEY` constraint, but I also wanted to have better visibility on occurring exceptions.